### PR TITLE
Update PropelEventPass.php

### DIFF
--- a/src/DependencyInjection/Compiler/PropelEventPass.php
+++ b/src/DependencyInjection/Compiler/PropelEventPass.php
@@ -29,7 +29,7 @@ class PropelEventPass implements CompilerPassInterface
                 $isClass = !empty($tag['class']);
                 
                 if ($isListener) {
-                    $priority = (int) @$tag['priority'];
+                    $priority = array_key_exists('priority', $tag) ? (int)$tag['priority'] : 0;
                     
                     if ($isClass) {
                         $classDefinition->addMethodCall('addListener', array(


### PR DESCRIPTION
Suppressing of error by operator "@" will produce hidden warning in logs, would be faster to use array_key_exists instead "@"